### PR TITLE
Add current node and ruby versions

### DIFF
--- a/3.2-18/alpine/Dockerfile
+++ b/3.2-18/alpine/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-alpine AS nodejs
+
+FROM ruby:3.2-alpine
+
+ENV NODE_MAJOR 18
+
+RUN addgroup -g 1000 node \
+  && adduser -u 1000 -G node -s /bin/sh -D node \
+  && apk add --no-cache \
+  libstdc++
+
+COPY --from=nodejs /usr/local/bin/node /usr/local/bin/
+COPY --from=nodejs /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodejs /opt/ /opt/
+
+RUN ln -sf /usr/local/bin/node /usr/local/bin/nodejs \
+  && ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+  && ln -sf /opt/yarn*/bin/yarn /usr/local/bin/yarn \
+  && ln -sf /opt/yarn*/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/3.2-18/bullseye-slim/Dockerfile
+++ b/3.2-18/bullseye-slim/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-bullseye-slim AS nodejs
+
+FROM ruby:3.2-slim-bullseye
+
+ENV LANG C.UTF-8
+
+ENV NODE_MAJOR 18
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+COPY --from=nodejs /usr/local/bin/node /usr/local/bin/
+COPY --from=nodejs /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodejs /opt/ /opt/
+
+RUN ln -sf /usr/local/bin/node /usr/local/bin/nodejs \
+  && ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+  && ln -sf /opt/yarn*/bin/yarn /usr/local/bin/yarn \
+  && ln -sf /opt/yarn*/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/3.2-20/alpine/Dockerfile
+++ b/3.2-20/alpine/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS nodejs
+
+FROM ruby:3.2-alpine
+
+ENV NODE_MAJOR 20
+
+RUN addgroup -g 1000 node \
+  && adduser -u 1000 -G node -s /bin/sh -D node \
+  && apk add --no-cache \
+  libstdc++
+
+COPY --from=nodejs /usr/local/bin/node /usr/local/bin/
+COPY --from=nodejs /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodejs /opt/ /opt/
+
+RUN ln -sf /usr/local/bin/node /usr/local/bin/nodejs \
+  && ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+  && ln -sf /opt/yarn*/bin/yarn /usr/local/bin/yarn \
+  && ln -sf /opt/yarn*/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/3.2-20/bullseye-slim/Dockerfile
+++ b/3.2-20/bullseye-slim/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-bullseye-slim AS nodejs
+
+FROM ruby:3.2-slim-bullseye
+
+ENV LANG C.UTF-8
+
+ENV NODE_MAJOR 20
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+COPY --from=nodejs /usr/local/bin/node /usr/local/bin/
+COPY --from=nodejs /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodejs /opt/ /opt/
+
+RUN ln -sf /usr/local/bin/node /usr/local/bin/nodejs \
+  && ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+  && ln -sf /opt/yarn*/bin/yarn /usr/local/bin/yarn \
+  && ln -sf /opt/yarn*/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,23 @@ services:
     build: 2-10/alpine/.
     image: ruby-node:2-10-alpine
     command: ls -la /usr/local/bin
+
+  rubynode-3.2-18-slim:
+    build: 3.2-18/bullseye-slim/.
+    image: ruby-node:3.2-18-slim
+    command: ls -la /usr/local/bin
+
+  rubynode-3.2-18-alpine:
+    build: 3.2-18/alpine/.
+    image: ruby-node:3.2-18-alpine
+    command: ls -la /usr/local/bin
+
+  rubynode-3.2-20-slim:
+      build: 3.2-18/bullseye-slim/.
+      image: ruby-node:3.2-18-slim
+      command: ls -la /usr/local/bin
+
+  rubynode-3.2-20-alpine:
+    build: 3.2-20/alpine/.
+    image: ruby-node:3.2-20-alpine
+    command: ls -la /usr/local/bin


### PR DESCRIPTION
Node 16 is out of its maintenance period, and thus isn't officially supported anymore.

This PR adds the combinations of Ruby 3.2 &times; Node 18 and Ruby 3.2 &times; Node 20 

[![image](https://github.com/Starefossen/docker-ruby-node/assets/351038/f5d1d9cd-532d-4212-9829-68f762d2268e)](https://nodejs.org/en/about/previous-releases)